### PR TITLE
Fix y-partyserver chunking

### DIFF
--- a/.changeset/neat-rats-care.md
+++ b/.changeset/neat-rats-care.md
@@ -1,0 +1,5 @@
+---
+"y-partyserver": patch
+---
+
+Fix y-partyserver chunking

--- a/packages/y-partyserver/src/shared/chunking.ts
+++ b/packages/y-partyserver/src/shared/chunking.ts
@@ -94,7 +94,7 @@ export const handleChunked = (
   let start: Batch | undefined;
 
   return (connection, message) => {
-    if (typeof message === "string") {
+    if (typeof message === "string" && !isBatchSentinel(message)) {
       return;
     }
     if (isBatchSentinel(message)) {


### PR DESCRIPTION
Chunking currently relies on detecting a `BATCH_SENTINEL` of type string. But string messages are currently ignored, causing chunking to fail. This PR restores the chunking functionality.