### PR TITLE
`alarm` vs `onAlarm`?

### DIFF
--- a/fixtures/todo-sync/src/server/index.ts
+++ b/fixtures/todo-sync/src/server/index.ts
@@ -87,7 +87,7 @@ export class ToDos extends SyncServer<
     }
     // });
   }
-  async alarm() {
+  async onAlarm() {
     // actually delete any todos that have been
     // marked as deleted more than 24 hours ago
     this.sql(


### PR DESCRIPTION
yo I just started playing with `partysync` and it's not clear to me in the todos example if I should be overwriting `onAlarm` or `alarm` or maybe call `alarm` but while ensuring that I call `super.alarm()` too

I'm asking bcs this `#initialize` bit seems pretty useful.

https://github.com/threepointone/partyserver/blob/817540e7ff16d469398be63d11b40234d48500f5/packages/partyserver/src/index.ts#L580-L593

So this PR changes the todos example to use `onAlarm` (if my intuition is right).