### PR TITLE
Close websocket if disconnect is called during CONNECTING state

### DIFF
--- a/.changeset/red-webs-throw.md
+++ b/.changeset/red-webs-throw.md
@@ -1,0 +1,5 @@
+---
+"partysocket": patch
+---
+
+Close websocket if disconnect is called during CONNECTING state

--- a/packages/partysocket/src/ws.ts
+++ b/packages/partysocket/src/ws.ts
@@ -523,7 +523,10 @@ const partysocket = new PartySocket({
     }
     this._removeListeners();
     try {
-      if (this._ws.readyState === this.OPEN || this._ws.readyState === this.CONNECTING) {
+      if (
+        this._ws.readyState === this.OPEN ||
+        this._ws.readyState === this.CONNECTING
+      ) {
         this._ws.close(code, reason);
       }
       this._handleClose(new Events.CloseEvent(code, reason, this));

--- a/packages/partysocket/src/ws.ts
+++ b/packages/partysocket/src/ws.ts
@@ -523,7 +523,7 @@ const partysocket = new PartySocket({
     }
     this._removeListeners();
     try {
-      if (this._ws.readyState === this.OPEN) {
+      if (this._ws.readyState === this.OPEN || this._ws.readyState === this.CONNECTING) {
         this._ws.close(code, reason);
       }
       this._handleClose(new Events.CloseEvent(code, reason, this));


### PR DESCRIPTION
Properly handle websocket disconnection when called during the CONNECTING state. Previously, sockets in this state weren't terminated, leaving them dangling in the CONNECTING state. If the disconnect was part of a connection retry, new sockets would attempt to connect while the original socket remained still trying to connect.

When the original connection eventually resolved, this created a thundering herd. And while those dropped connections wouldn't emit any events, it still imposes an undue burden on the target server as they will still receive messages (until the server or client decides to disconnect for some reason). 