### PR TITLE
fix(partytracks): export Screenshare type

### DIFF
--- a/packages/partytracks/src/client/index.ts
+++ b/packages/partytracks/src/client/index.ts
@@ -6,6 +6,7 @@ export {
 } from "./resilientTrack$";
 export { screenshare$ } from "./screenshare$";
 export { getScreenshare } from "./getScreenshare.ts";
+export type { Screenshare } from "./getScreenshare.ts";
 export { setLogLevel } from "./logging";
 export type { PartyTracksConfig, ApiHistoryEntry } from "./PartyTracks";
 export type { TrackMetadata } from "./callsTypes";


### PR DESCRIPTION
~Just changing the type of `isBroadcasting$` to it's correct type `BehaviorSubject`.~

~If we don't want that, might as well return it `asObservable()`.~

Update: Just exporting the `Screenshare` type.