### PR TITLE
feat: add enabled prop. 

### DIFF
--- a/packages/partysocket/src/react.ts
+++ b/packages/partysocket/src/react.ts
@@ -45,7 +45,7 @@ export default function usePartySocket(options: UsePartySocketOptions) {
       ])
   });
 
-  useAttachWebSocketEventHandlers(socket, options);
+  useAttachWebSocketEventHandlers(socket!, options);
 
   return socket;
 }

--- a/packages/partysocket/src/use-handlers.ts
+++ b/packages/partysocket/src/use-handlers.ts
@@ -11,7 +11,7 @@ export type EventHandlerOptions = {
 
 /** Attaches event handlers to a WebSocket in a React Lifecycle-friendly way */
 export const useAttachWebSocketEventHandlers = (
-  socket: WebSocket,
+  socket: WebSocket | null,
   options: EventHandlerOptions
 ) => {
   const handlersRef = useRef(options);
@@ -27,16 +27,16 @@ export const useAttachWebSocketEventHandlers = (
     const onError: EventHandlerOptions["onError"] = (event) =>
       handlersRef.current?.onError?.(event);
 
-    socket.addEventListener("open", onOpen);
-    socket.addEventListener("close", onClose);
-    socket.addEventListener("error", onError);
-    socket.addEventListener("message", onMessage);
+    socket?.addEventListener("open", onOpen);
+    socket?.addEventListener("close", onClose);
+    socket?.addEventListener("error", onError);
+    socket?.addEventListener("message", onMessage);
 
     return () => {
-      socket.removeEventListener("open", onOpen);
-      socket.removeEventListener("close", onClose);
-      socket.removeEventListener("error", onError);
-      socket.removeEventListener("message", onMessage);
+      socket?.removeEventListener("open", onOpen);
+      socket?.removeEventListener("close", onClose);
+      socket?.removeEventListener("error", onError);
+      socket?.removeEventListener("message", onMessage);
     };
   }, [socket]);
 };

--- a/packages/partysocket/src/use-socket.ts
+++ b/packages/partysocket/src/use-socket.ts
@@ -28,7 +28,7 @@ export function useStableSocket<T extends WebSocket, TOpts extends Options>({
   createSocketMemoKey: createOptionsMemoKey
 }: {
   options: TOpts;
-  createSocket: (options: TOpts) => T;
+  createSocket: (options: TOpts) => T | null;
   createSocketMemoKey: (options: TOpts) => string;
 }) {
   // ensure we only reconnect when necessary
@@ -39,7 +39,7 @@ export function useStableSocket<T extends WebSocket, TOpts extends Options>({
   }, [shouldReconnect]);
 
   // this is the socket we return
-  const [socket, setSocket] = useState<T>(() =>
+  const [socket, setSocket] = useState<T | null>(() =>
     // only connect on first mount
     createSocket({ ...socketOptions, startClosed: true })
   );
@@ -68,13 +68,13 @@ export function useStableSocket<T extends WebSocket, TOpts extends Options>({
     } else {
       // if this is the first time we are running the hook, connect...
       if (!socketInitializedRef.current && socketOptions.startClosed !== true) {
-        socket.reconnect();
+        socket?.reconnect();
       }
       // track initialized socket so we know not to do it again
       socketInitializedRef.current = socket;
       // close the old socket the next time the socket changes or we unmount
       return () => {
-        socket.close();
+        socket?.close();
       };
     }
   }, [socket, socketOptions]);


### PR DESCRIPTION
This PR adds an `enabled` prop to the `useWebSocket` hook, allowing conditional WebSocket connection control. When `enabled` is `false`, the connection is not established. This prevents unnecessary socket connections and avoids violating the React rules of hooks, which don't allow calling hooks conditionally.