### PR TITLE
Remove license information from README.md files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,8 @@
+ISC License
+
 Copyright 2024 Sunil Pai <spai@cloudflare.com>
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/partyagent/README.md
+++ b/packages/partyagent/README.md
@@ -14,7 +14,3 @@ Autonomous agents powered by Durable Objects. Extends PartySync for state synchr
 
 - [Building Effective Agents](https://www.anthropic.com/research/building-effective-agents)
 - [Agents Architecture](https://huyenchip.com/2025/01/07/agents.html)
-
-## License
-
-ISC

--- a/packages/partybase/README.md
+++ b/packages/partybase/README.md
@@ -7,7 +7,3 @@ Database solution for PartyServer built on Durable Objects.
 - **Migration System** - Built-in database migration capabilities
 - **Admin Interface** - Web interface for database management
 - **Starbase Integration** - Potential integration with [Starbase](https://starbasedb.com/)
-
-## License
-
-ISC

--- a/packages/partyflow/README.md
+++ b/packages/partyflow/README.md
@@ -1,7 +1,3 @@
 # partyflow
 
 Lightweight workflow engine for PartyServer built on Durable Objects.
-
-## License
-
-ISC

--- a/packages/partyfn/README.md
+++ b/packages/partyfn/README.md
@@ -6,7 +6,3 @@ RPC (Remote Procedure Call) system for PartyServer. Enables typesafe function ca
 
 - **Typesafe RPC** - Function calls from client to server
 - **Bidirectional** - Supports server-to-client RPC calls
-
-## License
-
-ISC

--- a/packages/partyhard/README.md
+++ b/packages/partyhard/README.md
@@ -1,7 +1,3 @@
 # partyhard
 
 A component of the PartyServer ecosystem.
-
-## License
-
-ISC

--- a/packages/partysession/README.md
+++ b/packages/partysession/README.md
@@ -6,7 +6,3 @@ One Durable Object per user model for PartyServer. Designed for managing user-sp
 
 - **Per-User State** - One Durable Object instance per user
 - **Session Management** - Handles user session data
-
-## License
-
-ISC

--- a/packages/partysmart/README.md
+++ b/packages/partysmart/README.md
@@ -1,7 +1,3 @@
 # partysmart
 
 Alternative name for PartyAgent. See [partyagent](../partyagent/README.md) for details.
-
-## License
-
-ISC

--- a/packages/partysocket/README.md
+++ b/packages/partysocket/README.md
@@ -223,7 +223,3 @@ OPEN       1 The connection is open and ready to communicate.
 CLOSING    2 The connection is in the process of closing.
 CLOSED     3 The connection is closed or couldn't be opened.
 ```
-
-## License
-
-MIT

--- a/packages/partysocket/package.json
+++ b/packages/partysocket/package.json
@@ -61,7 +61,7 @@
     "directory": "packages/partysocket"
   },
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "event-target-polyfill": "^0.0.4"
   },

--- a/packages/partysub/README.md
+++ b/packages/partysub/README.md
@@ -2,10 +2,6 @@
 
 Pub-sub functionality for Durable Objects in PartyServer.
 
-## License
-
-ISC
-
 ## 🥖 partysub
 
 > [!WARNING]

--- a/packages/partysync/README.md
+++ b/packages/partysync/README.md
@@ -2,10 +2,6 @@
 
 Experimental library to synchronize state between a Durable Object and client. See [design discussion](https://github.com/cloudflare/partykit/issues/147).
 
-## License
-
-ISC
-
 > [!WARNING]
 > WIP, API and design is subject to change.
 

--- a/packages/partytracks/README.md
+++ b/packages/partytracks/README.md
@@ -18,10 +18,6 @@ npm install partytracks
 
 A promise-based API (push a track, get a promise of metadata) seems simpler but proved to be a leaky abstraction when things go wrong. Sometimes a webcam is unplugged, or your peer connection drops when switching networks. Observables allow all of the logic of replacing/repairing tracks and connections to be contained within the library, allowing your application code to not be concerned with the details of WebRTC.
 
-## License
-
-ISC
-
 ## Usage
 
 ### Client code:

--- a/packages/partywhen/README.md
+++ b/packages/partywhen/README.md
@@ -2,10 +2,6 @@
 
 Sophisticated scheduler for durable tasks, built on Durable Object Alarms.
 
-## License
-
-ISC
-
 - schedule tasks by time, delay, or cron expression
 - schedule multiple tasks on the same object
 - query tasks by description or id (or by time range?)

--- a/packages/y-partyserver/README.md
+++ b/packages/y-partyserver/README.md
@@ -2,10 +2,6 @@
 
 Yjs backend for PartyServer.
 
-## License
-
-ISC
-
 [//]: # "keep in sync with packages/y-partyserver/README.md"
 [//]: # "keep in sync with docs/reference/y-partyserver.md"
 


### PR DESCRIPTION
The license information is already shown in the sidebar on npm and github so we can remove these from the READMEs