### PR TITLE
Improve y-partyserver override for custom implementation

### DIFF
--- a/.changeset/moody-shoes-start.md
+++ b/.changeset/moody-shoes-start.md
@@ -1,0 +1,5 @@
+---
+"y-partyserver": patch
+---
+
+y-partyserver: readonly mode, allow onConnect/onMessage override

--- a/packages/y-partyserver/src/server/index.ts
+++ b/packages/y-partyserver/src/server/index.ts
@@ -248,7 +248,9 @@ export class YServer<Env = unknown> extends Server<Env> {
     }
   }
 
-  onMessage = handleChunked((conn, message) => this.handleMessage(conn, message));
+  onMessage = handleChunked((conn, message) =>
+    this.handleMessage(conn, message)
+  );
 
   onClose(
     connection: Connection<unknown>,

--- a/packages/y-partyserver/src/server/index.ts
+++ b/packages/y-partyserver/src/server/index.ts
@@ -197,6 +197,11 @@ export class YServer<Env = unknown> extends Server<Env> {
     );
   }
 
+  isReadOnly(connection: Connection): boolean {
+    // to be implemented by the user
+    return false;
+  }
+
   // @ts-ignore something something typescript
   onMessage = handleChunked((conn, message) => {
     if (typeof message === "string") {
@@ -217,9 +222,8 @@ export class YServer<Env = unknown> extends Server<Env> {
             decoder,
             encoder,
             this.document,
-            conn,
-            // TODO: readonly conections
-            false
+            connection,
+            this.isReadOnly(connection)
           );
 
           // If the `encoder` only contains the type of reply message and no

--- a/packages/y-partyserver/src/shared/chunking.ts
+++ b/packages/y-partyserver/src/shared/chunking.ts
@@ -2,7 +2,7 @@
 // WebSocket messages. Because the Workers platform limits individual
 // WebSocket messages to 1MB, we need to split larger messages into chunks.
 
-import type { Connection } from "partyserver";
+import type { Connection, WSMessage } from "partyserver";
 
 export const CHUNK_MAX_SIZE = 1_000_000;
 
@@ -12,8 +12,7 @@ const trace = (...args: unknown[]) => TRACE_ENABLED && console.log(...args);
 
 let warnedAboutLargeMessage = false;
 
-type MessageData = ArrayBufferLike | string;
-type MessageHandler = (conn: Connection, message: MessageData) => void;
+type MessageHandler = (conn: Connection, message: WSMessage) => void;
 type Batch = {
   id: string;
   type: "start" | "end";
@@ -88,7 +87,7 @@ export const sendChunked = (data: Uint8Array, ws: WebSocket) => {
  * 4. The server forwards the message to handlers
  */
 export const handleChunked = (
-  receive: (conn: Connection, data: MessageData) => void
+  receive: (conn: Connection, data: WSMessage) => void
 ): MessageHandler => {
   let batch: ArrayBuffer[] | undefined;
   let start: Batch | undefined;
@@ -159,7 +158,7 @@ function assertEquality(expected: unknown, actual: unknown, label: string) {
 }
 
 /** Checks whether a message is batch marker */
-function isBatchSentinel(msg: MessageData): msg is string {
+function isBatchSentinel(msg: WSMessage): msg is string {
   return typeof msg === "string" && msg.startsWith(BATCH_SENTINEL);
 }
 


### PR DESCRIPTION
Using y-partyserver has some limitations for custom behaviors and uncovered cases

This PR updates methods 
* improve override for custom implementation
    * `onConnect`
        * Allow to return a Promise, so that we can override, perform async checks before continuing. The override implementation can throw or call super.
        * (In our case, we performed security and authorisation in the previous PartyKit implementation)
    *`handleMessage`
        * We can override the existing `onMessage`, as advised in the custom log, but the "property" syntax prevent us from calling `super.onMessage`. There's also a chunk mechanism that is internally implemented, and overriding onMessage would require making this public.
        * Create a `handleMessage` methods that allows override for custom messages, and calling `super.handleMessage` to still manage YJS messages.
        * (We used to reuse this socket to share updates on metadata which are not stored within the YJS doc)
* Add a way to manage ReadOnly messages on YJS.
    * Declare a method to override. This method must return a boolean (Maybe move to a Promise ?)
    * The implementation of readonly is left at the integrator:
        * Use the state of the connection to store some right management
        * Use the tags of the connections to "flag" a connection as readonly (Even if there's no immediate way to get the tags of a connection)
        * Use the DO context to store a state to compute the ReadOnly boolean.
    * (Allow migration from previous PartyKit implementation)