### PR TITLE
Update PartyServer README.md to use async fetch handler

### DIFF
--- a/packages/partyserver/README.md
+++ b/packages/partyserver/README.md
@@ -49,13 +49,13 @@ export class MyServer extends Server {
 
 export default {
   // Set up your fetch handler to use configured Servers
-  fetch(request, env) {
+  async fetch(request: Request, env: Env): Promise<Response> {
     return (
-      routePartykitRequest(request, env) ||
+      (await routePartykitRequest(request, env)) ||
       new Response("Not Found", { status: 404 })
     );
   }
-};
+} satisfies ExportedHandler<Env>;
 ```
 
 And configure your `wrangler.toml`:


### PR DESCRIPTION
Updates the example in the PartyServer README to match the examples in the `fixtures` directory. The existing example did not seem to work for me when setting up vitest integration tests.